### PR TITLE
HTTPMethod enum (POST/GET) shows up as part of History

### DIFF
--- a/src/components/history.rs
+++ b/src/components/history.rs
@@ -125,10 +125,11 @@ impl Component for History {
                 .iter()
                 .enumerate()
                 .map(|(index, f)| {
+                        let request_info = format!("{} {}", f.http_method, f.url);
                         if index == self.currently_selected_file {
-                            Line::from(f.url.clone()).style(Style::default().bg(Color::Blue))
+                            Line::from(request_info).style(Style::default().bg(Color::Blue))
                         } else {
-                            Line::from(f.url.clone())
+                            Line::from(request_info)
                         }
                 })
                 .collect::<Vec<_>>())


### PR DESCRIPTION
Small PR that allows to see whether request method is `POST` or `GET` inside History window

![image](https://github.com/user-attachments/assets/14a8f8da-e794-4e28-a587-2182c9c2988b)
