### PR TITLE
Automatically select and edit newly created header

### DIFF
--- a/src/components/headers.rs
+++ b/src/components/headers.rs
@@ -59,6 +59,9 @@ impl<'a> Headers<'a> {
 
     fn handle_add_header(&mut self) -> Option<Action> {
         self.headers.push(Header::new());
+        // Select the newly added header and enter edit mode
+        self.selected_header_index = self.headers.len() - 1;
+        self.handle_edit_header();
         None
     }
 


### PR DESCRIPTION
**BEFORE** Inside `Headers` clicking `a` to add new header would add a new header, but in order to edit it you would have to click `j` (down to new header) and then `e` to (edit mode)

**AFTER** Inside `Headers` clicking `a` would immediately select new header and open edit mode for it.