### PR TITLE
Tui Block highlight improvements

### DIFF
--- a/src/components/history.rs
+++ b/src/components/history.rs
@@ -3,7 +3,7 @@ use std::usize;
 use ratatui::{layout::Rect, style::{Color, Style}, symbols::scrollbar, text::Line, widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState}};
 use tui_textarea::{Input, Key};
 
-use crate::{action::Action, http_method::HTTPMethod, lazycurl_file:: LazyCurlFile};
+use crate::{action::Action, http_method::HTTPMethod, lazycurl_file:: LazyCurlFile, utils::tui_block::main_block};
 
 use super::Component;
 
@@ -115,11 +115,7 @@ impl Component for History {
             return Ok(())
         }
 
-        let mut border_style = Style::default();
-
-        if self.selected {
-            border_style.fg = Some(Color::Green);
-        }
+        let block = main_block(&self.selected, "History");
 
         let paragraph = Paragraph::new(self.lazycurl_files
                 .iter()
@@ -132,10 +128,7 @@ impl Component for History {
                         }
                 })
                 .collect::<Vec<_>>())
-            .block(Block::default()
-                .borders(Borders::ALL)
-                .title("History")
-                .border_style(border_style))
+            .block(block)
             .scroll((self.currently_selected_file as u16, 0));
 
         frame.render_widget(paragraph, area);

--- a/src/components/parameters.rs
+++ b/src/components/parameters.rs
@@ -120,7 +120,7 @@ impl<'a> Component for Parameters<'a> {
 
         let tab_titles = SelectedTab::iter().map(SelectedTab::title);
 
-        let block = main_block(&self.selected, "Parameters");
+        let block = main_block(&self.selected, "[2]-Parameters");
 
         Tabs::new(tab_titles)
             .block(block)

--- a/src/components/parameters.rs
+++ b/src/components/parameters.rs
@@ -3,7 +3,7 @@ use std::usize;
 use ratatui::{layout::{Constraint, Direction, Layout, Rect}, style::{Color, Style}, text::Line, widgets::{Block, Borders, Tabs, Widget}};
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-use crate::action::Action;
+use crate::{action::Action, utils::tui_block::main_block};
 
 use super::{body::Body, headers::Headers, Component};
 
@@ -120,14 +120,10 @@ impl<'a> Component for Parameters<'a> {
 
         let tab_titles = SelectedTab::iter().map(SelectedTab::title);
 
-        let mut border_style = Style::default();
-
-        if self.selected {
-            border_style.fg = Some(Color::Green);
-        }
+        let block = main_block(&self.selected, "Parameters");
 
         Tabs::new(tab_titles)
-            .block(Block::default().borders(Borders::ALL).title("Parameters").border_style(border_style))
+            .block(block)
             .highlight_style(Color::Yellow)
             .select(self.selected_tab as usize)
             .divider("|")

--- a/src/components/response.rs
+++ b/src/components/response.rs
@@ -2,7 +2,7 @@ use ratatui::{layout::Rect, style::{Color, Style}, widgets::{Block, Borders, Par
 use serde_json::Value;
 use tui_textarea::{Input, Key};
 
-use crate::action::Action;
+use crate::{action::Action, utils::tui_block::main_block};
 
 use super::Component;
 
@@ -68,6 +68,11 @@ impl Component for Response {
     }
 
     fn render_frame(&mut self, frame: &mut ratatui::prelude::Frame<'_>, area: Rect) -> std::io::Result<()> {
+        let block = main_block(&self.selected, "Response");
+        let p = Paragraph::new(self.response_value.as_str())
+                    .block(block);
+        frame.render_widget(p, area);
+
         if self.selected {
             let p = Paragraph::new(self.response_value.as_str())
                         .block(Block::default().title("Response").borders(Borders::ALL).style(Style::default().fg(Color::Green)));

--- a/src/components/response.rs
+++ b/src/components/response.rs
@@ -68,21 +68,11 @@ impl Component for Response {
     }
 
     fn render_frame(&mut self, frame: &mut ratatui::prelude::Frame<'_>, area: Rect) -> std::io::Result<()> {
-        let block = main_block(&self.selected, "Response");
+        let block = main_block(&self.selected, "[3]-Response");
         let p = Paragraph::new(self.response_value.as_str())
                     .block(block);
         frame.render_widget(p, area);
 
-        if self.selected {
-            let p = Paragraph::new(self.response_value.as_str())
-                        .block(Block::default().title("Response").borders(Borders::ALL).style(Style::default().fg(Color::Green)));
-            frame.render_widget(p, area);
-
-        } else {
-            let p = Paragraph::new(self.response_value.as_str())
-                        .block(Block::default().title("Response").borders(Borders::ALL));
-            frame.render_widget(p, area);
-        }
         Ok(())
     }
 }

--- a/src/components/url.rs
+++ b/src/components/url.rs
@@ -165,7 +165,7 @@ impl<'a> Component for Url<'a> {
 
     fn render_frame(&mut self, frame: &mut ratatui::prelude::Frame<'_>, area: Rect) -> std::io::Result<()> {
         let http_method_lines = HTTPMethod::iter().map(HTTPMethod::line);
-        let block = main_block(&self.selected, "URL (press E to edit, enter to submit");
+        let block = main_block(&self.selected, "[1]—URL—(press E to edit, enter to submit)");
 
         Tabs::new(http_method_lines)
             .block(block)

--- a/src/components/url.rs
+++ b/src/components/url.rs
@@ -1,5 +1,6 @@
 use crate::action::Action;
 use crate::http_method::HTTPMethod;
+use crate::utils::tui_block::main_block;
 use crate::utils::tui_frame_util::centered_rect;
 
 use super::Component;
@@ -146,7 +147,7 @@ impl<'a> Component for Url<'a> {
                         self.handle_deselect();
                         Some(Action::Window3Request)
                     },
-                    _ => None 
+                    _ => None
                 }
             }
             Err(_) => Some(Action::Suspend)
@@ -164,14 +165,10 @@ impl<'a> Component for Url<'a> {
 
     fn render_frame(&mut self, frame: &mut ratatui::prelude::Frame<'_>, area: Rect) -> std::io::Result<()> {
         let http_method_lines = HTTPMethod::iter().map(HTTPMethod::line);
-        let mut border_style = Style::default();
-
-        if self.selected {
-            border_style.fg = Some(Color::Green);
-        }
+        let block = main_block(&self.selected, "URL (press E to edit, enter to submit");
 
         Tabs::new(http_method_lines)
-            .block(Block::default().borders(Borders::ALL).title("URL (press E to edit, enter to submit)").border_style(border_style))
+            .block(block)
             .highlight_style(Color::LightYellow)
             .select(self.http_method as usize)
             .divider("|")

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod tui_frame_util;
 pub mod curl_service;
 pub mod directory;
+pub mod tui_block;

--- a/src/utils/tui_block.rs
+++ b/src/utils/tui_block.rs
@@ -1,0 +1,25 @@
+use ratatui::widgets::{ Borders, Block };
+use ratatui::prelude::{ Style, Modifier };
+use ratatui::style::Color;
+
+pub fn main_block<'a>(selected: &bool, title: &'a str) -> Block<'a> {
+    // Highlight color
+    let border_style = if *selected {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default()
+    };
+
+    // Higlight title
+    let title_style = if *selected {
+        Style::default().add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+    };
+
+    Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .title_style(title_style)
+        .border_style(border_style)
+}


### PR DESCRIPTION
Changes:
- Logic for creating new `ratatui Block` (main_block) with `self.selected` highlight value moved to a single file `/src/utils/tui_block.rs` instead of spread out.
- Added `title` to be bold on `self.selected` for better visibility
- Added numbers to all selectable windows to their corresponding key bindings for example `[2]-Parameters`.

Screenshots

Before:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/715a3fde-8850-4380-9672-62c5afaa272a">


After:
<img width="594" alt="image" src="https://github.com/user-attachments/assets/2a46fcd6-c4fc-45db-99a2-0c3e07bc0d37">
